### PR TITLE
260502 Code Rollups

### DIFF
--- a/pylib/iemweb/afos/retrieve.py
+++ b/pylib/iemweb/afos/retrieve.py
@@ -181,7 +181,8 @@ class Schema(CGIModel):
                 "resembles what would have been sent over the NWS NOAAPort "
                 "system. The ``html`` format is a bit more human readable. "
                 "The ``zip`` format will return a zip file containing the "
-                "text products, one file per product."
+                "text products, one file per product. The ``zip`` format is "
+                "not supported for the one-off ``MTR`` METAR service."
             ),
             pattern="^(text|html|zip)$",
         ),
@@ -484,6 +485,12 @@ def application(environ: dict, start_response: callable):
         )
 
     if request.pil[0].startswith("MTR"):
+        if request.fmt == "zip":
+            start_response(
+                "422 Unprocessable Entity",
+                [("Content-type", "text/plain")],
+            )
+            return "ERROR: The zip format is not supported for the MTR service"
         with get_sqlalchemy_conn("iem") as conn:
             start_response("200 OK", headers)
             return special_metar_logic(conn, request)

--- a/pylib/iemweb/autoplot/scripts/p31.py
+++ b/pylib/iemweb/autoplot/scripts/p31.py
@@ -140,6 +140,8 @@ def get_description():
             name="fdays",
             default=1,
             label="Number of Days in Forward Period (following middle):",
+            ge=1,
+            le=366,
         ),
         dict(
             type="select",
@@ -163,7 +165,7 @@ def plotter(ctx: dict):
     """Go"""
     station = ctx["station"]
     days = int(ctx["days"])
-    fdays = int(ctx["fdays"])
+    fdays = max(1, ctx["fdays"])
     mdays = int(ctx["mdays"])
     syear = int(ctx["syear"])
     eyear = int(ctx["eyear"])

--- a/pylib/iemweb/autoplot/scripts/p78.py
+++ b/pylib/iemweb/autoplot/scripts/p78.py
@@ -186,8 +186,9 @@ def plotter(ctx: dict):
     y2.set_ylabel("Mean Relative Humidity [%] (black line)")
     y2.set_yticks([0, 5, 10, 25, 50, 75, 90, 95, 100])
     y2.set_ylim(0, 100)
-    ax.set_ylim(xmin, xmax)
-    ax.set_xlim(xmin, xmax)
+    if xmax > xmin:
+        ax.set_ylim(xmin, xmax)
+        ax.set_xlim(xmin, xmax)
     ax.set_xlabel("Air Temperature °F")
 
     if ctx.get("date"):

--- a/pylib/iemweb/geojson/agclimate.py
+++ b/pylib/iemweb/geojson/agclimate.py
@@ -42,6 +42,8 @@ from pyiem.tracker import loadqc
 from pyiem.util import convert_value, drct2text, mm2inch, utc
 from pyiem.webutil import CGIModel, iemapp
 
+from iemweb.util import json_response_dict
+
 
 class Schema(CGIModel):
     """See how we are called."""
@@ -130,7 +132,7 @@ def compute_plant_water(row):
 def get_inversion_data(conn, ts):
     """Retrieve inversion data."""
     nt = NetworkTable("ISUSM", only_online=False)
-    data = {"type": "FeatureCollection", "features": []}
+    data = json_response_dict({"type": "FeatureCollection", "features": []})
     res = conn.execute(
         sql_helper(
             "select *, case when tair_10_c_avg > tair_15_c_avg then true else "

--- a/pylib/iemweb/geojson/cf6.py
+++ b/pylib/iemweb/geojson/cf6.py
@@ -31,12 +31,11 @@ import simplejson as json
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
 from pyiem.reference import TRACE_VALUE
-from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 from simplejson import encoder
 
 from iemweb.fields import CALLBACK_FIELD
-from iemweb.util import get_ct
+from iemweb.util import get_ct, json_response_dict
 
 encoder.FLOAT_REPR = lambda o: format(o, ".2f")
 
@@ -91,11 +90,12 @@ def f2_sanitize(val):
 
 def get_data(conn, ts, fmt):
     """Get the data for this timestamp"""
-    data = {
-        "type": "FeatureCollection",
-        "generated_at": utc().strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "features": [],
-    }
+    data = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     # Fetch the daily values
     res = conn.execute(
         sql_helper("""

--- a/pylib/iemweb/geojson/cli.py
+++ b/pylib/iemweb/geojson/cli.py
@@ -43,12 +43,11 @@ import simplejson as json
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
 from pyiem.reference import TRACE_VALUE
-from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 from simplejson import encoder
 
 from iemweb.fields import CALLBACK_FIELD
-from iemweb.util import get_ct
+from iemweb.util import get_ct, json_response_dict
 
 encoder.FLOAT_REPR = lambda o: format(o, ".2f")
 
@@ -106,11 +105,12 @@ def f2_sanitize(val):
 
 def get_data(conn, ts, fmt):
     """Get the data for this timestamp"""
-    data = {
-        "type": "FeatureCollection",
-        "generated_at": utc().strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "features": [],
-    }
+    data = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     # Fetch the daily values
     res = conn.execute(
         sql_helper("""

--- a/pylib/iemweb/geojson/climodat_dayclimo.py
+++ b/pylib/iemweb/geojson/climodat_dayclimo.py
@@ -31,6 +31,7 @@ from pyiem.webutil import CGIModel, iemapp
 from sqlalchemy import Connection
 
 from iemweb.fields import CALLBACK_FIELD, NETWORK_FIELD
+from iemweb.util import json_response_dict
 
 
 class Schema(CGIModel):
@@ -108,13 +109,15 @@ def run(conn: Connection, network, month, day, syear, eyear):
         ),
         {"sday": sday, "syear": syear, "eyear": eyear},
     )
-    data = {
-        "type": "FeatureCollection",
-        "month": month,
-        "day": day,
-        "network": network,
-        "features": [],
-    }
+    data = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "month": month,
+            "day": day,
+            "network": network,
+            "features": [],
+        }
+    )
 
     for i, row in enumerate(res.mappings()):
         if row["station"] not in nt.sts:

--- a/pylib/iemweb/geojson/network.py
+++ b/pylib/iemweb/geojson/network.py
@@ -46,11 +46,10 @@ from typing import Annotated
 
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
-from pyiem.reference import ISO8601
-from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 
 from iemweb.fields import CALLBACK_FIELD, NETWORK_FIELD
+from iemweb.util import json_response_dict
 
 XREF = {
     "HAS_HML": "HAS_HML",
@@ -114,12 +113,12 @@ def run(conn, network, only_online: bool, has_attribute: str | None):
         params,
     )
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-        "count": cursor.rowcount,
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
 
     for row in cursor.mappings():
         ab = row["archive_begin"]
@@ -163,6 +162,7 @@ def run(conn, network, only_online: bool, has_attribute: str | None):
                 geometry=json.loads(row["geojson"]),
             )
         )
+    res["count"] = len(res["features"])
     return json.dumps(res)
 
 

--- a/pylib/iemweb/geojson/nexrad_attr.py
+++ b/pylib/iemweb/geojson/nexrad_attr.py
@@ -50,7 +50,7 @@ from pyiem.webutil import CGIModel, iemapp
 from sqlalchemy import Connection
 
 from iemweb.fields import CALLBACK_FIELD
-from iemweb.util import get_ct
+from iemweb.util import get_ct, json_response_dict
 
 
 class Schema(CGIModel):
@@ -112,12 +112,12 @@ def run(valid, fmt, conn: Connection = None):
         )
 
     if fmt == "geojson":
-        data = {
-            "type": "FeatureCollection",
-            "features": [],
-            "generated_at": utc().strftime(ISO8601),
-            "count": res.rowcount,
-        }
+        data = json_response_dict(
+            {
+                "type": "FeatureCollection",
+                "features": [],
+            }
+        )
         for i, row in enumerate(res.mappings()):
             data["features"].append(
                 {
@@ -147,6 +147,7 @@ def run(valid, fmt, conn: Connection = None):
                     },
                 }
             )
+        data["count"] = len(data["features"])
         return json.dumps(data)
     data = (
         "nexrad,storm_id,azimuth,range,tvs,meso,posh,poh,max_size,"

--- a/pylib/iemweb/geojson/sbw.py
+++ b/pylib/iemweb/geojson/sbw.py
@@ -60,7 +60,7 @@ from pyiem.webutil import CGIModel, ListOrCSVType, iemapp
 
 from iemweb.fields import CALLBACK_FIELD, STATE_LIST_FIELD_OPTIONAL
 from iemweb.mlib import rectify_wfo, unrectify_wfo
-from iemweb.util import get_ct
+from iemweb.util import get_ct, json_response_dict
 
 
 class Schema(CGIModel):
@@ -145,11 +145,12 @@ def run(query: Schema):
         "ets": query.ets,
     }
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
 
     wfo_limiter = ""
     if wfos:

--- a/pylib/iemweb/geojson/seven_am.py
+++ b/pylib/iemweb/geojson/seven_am.py
@@ -48,6 +48,7 @@ from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 
 from iemweb.fields import CALLBACK_FIELD
+from iemweb.util import json_response_dict
 
 
 class Schema(CGIModel):
@@ -112,12 +113,12 @@ def run_azos(ts: datetime):
         (ts0, ts1),
     )
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-        "count": cursor.rowcount,
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     tstamp = ts1.astimezone(timezone.utc).strftime(ISO8601)
     for row in cursor:
         res["features"].append(
@@ -142,6 +143,7 @@ def run_azos(ts: datetime):
             )
         )
     pgconn.close()
+    res["count"] = len(res["features"])
     return json.dumps(res)
 
 
@@ -161,12 +163,12 @@ def run_coop(ts):
         (ts.date(),),
     )
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-        "count": cursor.rowcount,
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     for row in cursor:
         res["features"].append(
             dict(
@@ -192,6 +194,7 @@ def run_coop(ts):
             )
         )
     pgconn.close()
+    res["count"] = len(res["features"])
     return json.dumps(res)
 
 
@@ -212,12 +215,12 @@ def run_cocorahs(ts: datetime):
         (ts.date(),),
     )
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-        "count": cursor.rowcount,
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     for row in cursor:
         res["features"].append(
             dict(
@@ -243,6 +246,7 @@ def run_cocorahs(ts: datetime):
             )
         )
     pgconn.close()
+    res["count"] = len(res["features"])
     return json.dumps(res)
 
 

--- a/pylib/iemweb/geojson/station_neighbors.py
+++ b/pylib/iemweb/geojson/station_neighbors.py
@@ -31,12 +31,10 @@ from typing import Annotated
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
 from pyiem.exceptions import IncompleteWebRequest
-from pyiem.reference import ISO8601
-from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 
 from iemweb.fields import CALLBACK_FIELD, NETWORK_FIELD
-from iemweb.util import get_ct
+from iemweb.util import get_ct, json_response_dict
 
 
 class Schema(CGIModel):
@@ -92,12 +90,12 @@ def run(conn, environ: dict):
         environ,
     )
 
-    res = {
-        "type": "FeatureCollection",
-        "features": [],
-        "generated_at": utc().strftime(ISO8601),
-        "count": cursor.rowcount,
-    }
+    res = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
 
     for row in cursor.mappings():
         ab = row["archive_begin"]
@@ -142,6 +140,7 @@ def run(conn, environ: dict):
                 geometry=json.loads(row["geojson"]),
             )
         )
+    res["count"] = len(res["features"])
     return json.dumps(res, ensure_ascii=False)
 
 

--- a/pylib/iemweb/geojson/usdm.py
+++ b/pylib/iemweb/geojson/usdm.py
@@ -38,11 +38,10 @@ from typing import Annotated
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
 from pyiem.exceptions import IncompleteWebRequest
-from pyiem.reference import ISO8601
-from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 
 from iemweb.fields import CALLBACK_FIELD
+from iemweb.util import json_response_dict
 
 
 class Schema(CGIModel):
@@ -78,7 +77,12 @@ def rectify_date(dt: dateobj):
 
 def run(ts: dateobj):
     """Actually do the hard work of getting the USDM in geojson"""
-    utcnow = utc()
+    data = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+    )
     with get_sqlalchemy_conn("postgis") as conn:
         res = conn.execute(
             sql_helper(
@@ -97,12 +101,6 @@ def run(ts: dateobj):
                 {"ts": ts - timedelta(days=7)},
             )
 
-        data = {
-            "type": "FeatureCollection",
-            "features": [],
-            "generated_at": utcnow.strftime(ISO8601),
-            "count": res.rowcount,
-        }
         for row in res.mappings():
             data["features"].append(
                 dict(
@@ -114,6 +112,7 @@ def run(ts: dateobj):
                     geometry=json.loads(row["geojson"]),
                 )
             )
+    data["count"] = len(data["features"])
     return json.dumps(data)
 
 

--- a/pylib/iemweb/geojson/webcam.py
+++ b/pylib/iemweb/geojson/webcam.py
@@ -35,6 +35,7 @@ from pyiem.util import utc
 from pyiem.webutil import CGIModel, iemapp
 
 from iemweb.fields import CALLBACK_FIELD, NETWORK_FIELD
+from iemweb.util import json_response_dict
 
 
 class Schema(CGIModel):
@@ -58,6 +59,16 @@ def run(valid, network):
     if network == "TV":
         networks = ["KCRG", "KCCI", "KELO", "ISUC", "MCFC"]
     params = {"networks": networks, "valid": valid}
+    data = json_response_dict(
+        {
+            "type": "FeatureCollection",
+            "features": [],
+            "valid_at": (valid if valid is not None else utc()).strftime(
+                ISO8601
+            ),
+        }
+    )
+
     with get_sqlalchemy_conn("mesosite") as conn:
         if valid is None:
             res = conn.execute(
@@ -81,16 +92,6 @@ def run(valid, network):
             """),
                 params,
             )
-        data = {
-            "type": "FeatureCollection",
-            "features": [],
-            "valid_at": (valid if valid is not None else utc()).strftime(
-                ISO8601
-            ),
-            "generated_at": utc().strftime(ISO8601),
-            "count": res.rowcount,
-        }
-
         for row in res.mappings():
             cv = row["valid"].astimezone(timezone.utc)
             url = (
@@ -119,6 +120,7 @@ def run(valid, network):
                     },
                 )
             )
+    data["count"] = len(data["features"])
     return json.dumps(data)
 
 

--- a/pylib/iemweb/json/wpcoutlook.py
+++ b/pylib/iemweb/json/wpcoutlook.py
@@ -32,7 +32,13 @@ https://mesonet.agron.iastate.edu/json/wpcoutlook.py\
 Provide the day 1 outlook for Pierre, SD valid at 8 UTC on 3 Aug 2024
 
 https://mesonet.agron.iastate.edu/json/wpcoutlook.py\
-?lat=44.368&lon=-100.336&day=1&time=2024-08-03T08:00Z
+?lat=44.368&lon=-100.336&day=1&time=2024-08-03T08:00
+
+Same request, but for 8 AM CDT
+
+https://mesonet.agron.iastate.edu/json/wpcoutlook.py\
+?lat=44.368&lon=-100.336&day=1&time=2024-08-03T08:00-05:00
+
 
 Get only the last day 2 outlook for Washington, DC
 
@@ -49,6 +55,7 @@ from typing import Annotated
 import pandas as pd
 from pydantic import Field
 from pyiem.database import get_sqlalchemy_conn, sql_helper
+from pyiem.exceptions import IncompleteWebRequest
 from pyiem.nws.products.spcpts import THRESHOLD_ORDER
 from pyiem.reference import ISO8601
 from pyiem.util import utc
@@ -108,16 +115,23 @@ def process_df(outlooks: pd.DataFrame) -> pd.DataFrame:
     return outlooks
 
 
-def dotime(time, lon, lat, day) -> tuple[pd.DataFrame, datetime]:
+def dotime(time: str, lon, lat, day) -> tuple[pd.DataFrame, datetime]:
     """Query for Outlook based on some timestamp"""
     if time in ["", "current", "now"]:
         ts = utc()
         if day > 1:
             ts += timedelta(days=day - 1)
     else:
-        # ISO formatting
-        ts = datetime.strptime(time[:16], "%Y-%m-%dT%H:%M")
-        ts = ts.replace(tzinfo=timezone.utc)
+        try:
+            ts = datetime.fromisoformat(time.replace("Z", "+00:00"))
+        except ValueError as exp:
+            raise IncompleteWebRequest(
+                "time must be a valid ISO8601 timestamp"
+            ) from exp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        else:
+            ts = ts.astimezone(timezone.utc)
     with get_sqlalchemy_conn("postgis") as conn:
         outlooks = pd.read_sql(
             sql_helper("""

--- a/pylib/iemweb/json/wpcoutlook.py
+++ b/pylib/iemweb/json/wpcoutlook.py
@@ -116,7 +116,7 @@ def dotime(time, lon, lat, day) -> tuple[pd.DataFrame, datetime]:
             ts += timedelta(days=day - 1)
     else:
         # ISO formatting
-        ts = datetime.strptime(time, "%Y-%m-%dT%H:%MZ")
+        ts = datetime.strptime(time[:16], "%Y-%m-%dT%H:%M")
         ts = ts.replace(tzinfo=timezone.utc)
     with get_sqlalchemy_conn("postgis") as conn:
         outlooks = pd.read_sql(

--- a/tests/iemweb/urls422.txt
+++ b/tests/iemweb/urls422.txt
@@ -1,4 +1,5 @@
 /afos/retrieve.py?sdate=2024-1-1&edate=2024-1-31&pil=DSMDSMDSM
+/afos/retrieve.py?pil=MTRDSM&fmt=zip
 /autoplot/autoplot.py?q=84&sector=IA&network=WFO&src:mrms&opt=per&usdm=yes&ptype=g&date=2021-07-25\xc2\xa7or&edate=2021-07-31&clip=yes&cmap=BrBG::_r=t&dpi=100&fmt=geotiff
 /autoplot/index.py?edate=2013%2F10%2F14&opt=acc&ptype=c&q=84&sdate=2013%2F10%2F01§or%3DIA&src=mrms&usdm=no
 /autoplot/index.py?_opt_edate=on&_opt_sdate=on&_r=t&_wait=no&cmap=jet&dpi=100&edate=0729%C2%A7or%3Dmidwest&month=all&opt=both&q=125&sdate=0723&src=ncei_climate91&state=IA&var=avg_high

--- a/tests/iemweb/urls422.txt
+++ b/tests/iemweb/urls422.txt
@@ -77,4 +77,5 @@
 /json/stage4.py?valid=2024-08-11&lon=-102.30&lat=45.10&tz=Boguis
 /json/snowfall_observations_v2.py?wfo=QQQ
 /json/spcoutlook.py?lat=38.907&lon=-77.037&day=4&last=1&cat=ANYS
+/json/wpcoutlook.py?time=crud
 /rainfall/mrms2img.py?year=2016&month=4&day=13&hour=18&minute=0&period=3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MTR METAR service now returns HTTP 422 for zip format requests
  * Plot p78 avoids applying invalid/degenerate axis ranges
  * WPC Outlook JSON endpoint accepts ISO8601 timestamps and gives clearer error on parse failure

* **Improvements**
  * Autoplot p31 "Forward Days" input constrained to 1–366
  * GeoJSON endpoints unified response initialization; removed generated_at and compute count from actual features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->